### PR TITLE
POC - Use ipc messages for end of game / storing state, but not main game

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "math-break",
   "version": "1.0.0",
   "description": "",
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "main": "src/main.js",
   "scripts": {
     "debug": "electron . --debug",

--- a/src/events.js
+++ b/src/events.js
@@ -1,0 +1,50 @@
+const { contextBridge, ipcRenderer } = require("electron");
+
+// render "listen" events
+const RECEIVE_GAME_OVER = "receive-game-over";
+const RECEIVE_LATEST_SCORE = "receive-latest-score";
+
+const listenAllowlist = [RECEIVE_GAME_OVER, RECEIVE_LATEST_SCORE];
+
+// render "send" events
+const REQUEST_GAME_OVER = "request-game-over";
+const REQUEST_LATEST_SCORE = "request-latest-score";
+
+const sendAllowlist = [REQUEST_GAME_OVER, REQUEST_LATEST_SCORE];
+
+const exposeIpcInMainWorld = () => {
+  // Expose protected methods that allow the renderer process to use
+  // the ipcRenderer without exposing the entire object
+  contextBridge.exposeInMainWorld("ipc", {
+    events: {
+      RECEIVE_GAME_OVER,
+      RECEIVE_LATEST_SCORE,
+      REQUEST_GAME_OVER,
+      REQUEST_LATEST_SCORE,
+    },
+    send: (channel, data) => {
+      // only allow named channels
+      let validChannels = sendAllowlist;
+      if (validChannels.includes(channel)) {
+        ipcRenderer.send(channel, data);
+      }
+    },
+    on: (channel, func) => {
+      let validChannels = listenAllowlist;
+      if (validChannels.includes(channel)) {
+        // Deliberately strip event as it includes `sender`
+        ipcRenderer.on(channel, (event, ...args) => func(...args));
+      }
+    },
+  });
+};
+
+module.exports = {
+  RECEIVE_GAME_OVER,
+  RECEIVE_LATEST_SCORE,
+  REQUEST_GAME_OVER,
+  REQUEST_LATEST_SCORE,
+  exposeIpcInMainWorld,
+  listenAllowlist,
+  sendAllowlist,
+};

--- a/src/main-process/gameOverHandler.js
+++ b/src/main-process/gameOverHandler.js
@@ -1,0 +1,29 @@
+const { ipcMain } = require("electron");
+const { promises: fs } = require("fs");
+
+const { REQUEST_GAME_OVER, RECEIVE_GAME_OVER } = require("../events");
+
+const gameOverHandler = (app) => {
+  ipcMain.on(REQUEST_GAME_OVER, async (event, args) => {
+    const userDataPath = app.getPath("userData");
+
+    const scores = JSON.stringify({
+      rounds: args.rounds,
+      score: args.score,
+      duration: args.duration,
+    });
+
+    try {
+      console.log(`saving Data to ${userDataPath}/scores.json`);
+      await fs.writeFile(`${userDataPath}/scores.json`, scores);
+
+      event.reply(RECEIVE_GAME_OVER);
+    } catch (err) {
+      // TODO - add generic "error" event & handling here
+    }
+  });
+};
+
+module.exports = {
+  gameOverHandler,
+};

--- a/src/main-process/latestScoreHandler.js
+++ b/src/main-process/latestScoreHandler.js
@@ -1,0 +1,23 @@
+const { ipcMain } = require("electron");
+const { promises: fs } = require("fs");
+
+const { REQUEST_LATEST_SCORE, RECEIVE_LATEST_SCORE } = require("../events");
+
+const latestScoreHandler = (app) => {
+  ipcMain.on(REQUEST_LATEST_SCORE, async (event) => {
+    const userDataPath = app.getPath("userData");
+
+    try {
+      console.log(`retrieving Data from ${userDataPath}/scores.json`);
+      const file = await fs.readFile(`${userDataPath}/scores.json`);
+
+      event.reply(RECEIVE_LATEST_SCORE, JSON.parse(file));
+    } catch (err) {
+      // TODO - add generic "error" event & handling here
+    }
+  });
+};
+
+module.exports = {
+  latestScoreHandler,
+};

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,9 @@
 const { app, BrowserWindow } = require("electron");
 const path = require("path");
 
+const { gameOverHandler } = require("./main-process/gameOverHandler");
+const { latestScoreHandler } = require("./main-process/latestScoreHandler");
+
 const isDebugMode = /--debug/.test(process.argv[2]);
 
 let mainWindow = null;
@@ -62,6 +65,9 @@ app.whenReady().then(() => {
     // dock icon is clicked and there are no other windows open.
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
+
+  gameOverHandler(app);
+  latestScoreHandler(app);
 });
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,17 +1,21 @@
 const { contextBridge } = require("electron");
 const { Game } = require("./classes/Game");
+const { exposeIpcInMainWorld } = require("./events");
 
 const CurrentGame = new Game();
 
 contextBridge.exposeInMainWorld("gameMethods", {
   answerQuestion: (answer) => CurrentGame.answerQuestion(answer),
   info: () => ({
+    duration: CurrentGame.timer.currentValue,
     gameOver: CurrentGame.gameOver,
     overallScore: CurrentGame.overallScore,
     question: CurrentGame.question,
+    rounds: CurrentGame.rounds,
     score: CurrentGame.score,
-    duration: CurrentGame.timer.currentValue,
   }),
   newGame: (opts) => CurrentGame.newGame(opts),
   nextQuestion: () => CurrentGame.nextQuestion(),
 });
+
+exposeIpcInMainWorld();

--- a/src/render-process/.eslintrc
+++ b/src/render-process/.eslintrc
@@ -1,5 +1,6 @@
 {
   "globals": {
-    "gameMethods": "readonly"
+    "gameMethods": "readonly",
+    "ipc": "readonly"
   }
 }

--- a/src/render-process/game-over.js
+++ b/src/render-process/game-over.js
@@ -4,7 +4,12 @@ const replaceText = (selector, text) => {
 };
 
 window.addEventListener("DOMContentLoaded", () => {
-  const score = localStorage.getItem("finalScore");
-  const duration = localStorage.getItem("duration");
-  replaceText("your-score", `You scored ${score} in ${duration}`);
+  ipc.send(ipc.events.REQUEST_LATEST_SCORE);
+
+  ipc.on(
+    ipc.events.RECEIVE_LATEST_SCORE,
+    ({ score, rounds, duration } = {}) => {
+      replaceText("your-score", `You scored ${score}/${rounds} in ${duration}`);
+    }
+  );
 });

--- a/src/render-process/gameplay.js
+++ b/src/render-process/gameplay.js
@@ -33,7 +33,19 @@ window.addEventListener("DOMContentLoaded", () => {
     if (gameOver) {
       localStorage.setItem("finalScore", overallScore);
       localStorage.setItem("duration", duration);
-      window.location = "game-over.html";
+
+      const { rounds, score } = gameMethods.info();
+
+      ipc.send(ipc.events.REQUEST_GAME_OVER, {
+        duration,
+        rounds,
+        score,
+      });
+
+      ipc.on(ipc.events.RECEIVE_GAME_OVER, () => {
+        window.location = "game-over.html";
+      });
+
       return;
     }
 


### PR DESCRIPTION
This is a hybrid approach between #8 and current.

### What happens
- Game plays out within preload
- After game, results sent with "request-game-over" event
- On results screen, stored information requested via. "request-latest-score" event

### Pros
- Less async events flying around during the game
- Less chance of the UI ending up in an unexpected state because we're not handling lots of events

### Cons
- User able to store arbritrary data if they send a game over event manually
  - We'd have to introduce some kind of validation for the incoming event payload which is a bit annoying